### PR TITLE
Harden systemd unit

### DIFF
--- a/cozy-stack.service
+++ b/cozy-stack.service
@@ -7,8 +7,26 @@ After=network.target couchdb.service
 User=cozy-stack
 Group=cozy
 PermissionsStartOnly=true
+WorkingDirectory=~
+LogsDirectory=cozy
+StateDirectory=cozy
 ExecStart=/usr/bin/cozy-stack serve
 Restart=always
+CapabilityBoundingSet=
+NoNewPrivileges=True
+PrivateUsers=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ProtectControlGroups=yes
+ProtectKernelTunables=true
+ProtectKernelModules=yes
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
À tester. Ça fonctionne sous Arch, mais je n’ai toujours pas de Konnectors pour l’instant, il est possible que ça cause des soucis à nsjail (déjà, vu l’emplacement du chroot je pense qu’un `ReadWritePaths=/usr/share/cozy/chroot` va être nécessaire).

Aussi, je n’ai pas vérifié que tout ce qui est listé est disponible dans la version de systemd sous Debian.